### PR TITLE
Added lseek64 and open64 implementations on macOS

### DIFF
--- a/dr_fs.h
+++ b/dr_fs.h
@@ -202,6 +202,10 @@ typedef uint32_t         dr_uint32;
 typedef int64_t          dr_int64;
 typedef uint64_t         dr_uint64;
 #endif
+#ifdef __APPLE__
+#define lseek64          lseek
+#define open64           open
+#endif
 typedef dr_uint8         dr_bool8;
 typedef dr_uint32        dr_bool32;
 #define DR_TRUE          1


### PR DESCRIPTION
macOS only offers implementations for `lseek()` and `open`

see manual pages for [lseek](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/lseek.2.html) and [open](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/open.2.html).